### PR TITLE
docs: correct Apps Script naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # marketdatabase
-App Script para buscar y extraer información de activos financieros
+Apps Script para buscar y extraer información de activos financieros


### PR DESCRIPTION
## Summary
- rename "App Script" to "Apps Script" in README

## Testing
- `npm test` *(fails: missing package.json)*
- `rg "App Script" -n`

------
https://chatgpt.com/codex/tasks/task_e_68adf8ca9280832fac43ce835e3512d4