### PR TITLE
Adjust certificates priority in Investing ranking

### DIFF
--- a/codigo.gs
+++ b/codigo.gs
@@ -10,7 +10,7 @@
  *  - COINGECKO (coins/markets)
  *  - INVESTING (HTML scraping robusto)
  *      · Identificador preferido = ISIN si está disponible (fondos/ETFs/bonos)
- *      · Búsqueda por ISIN con ranking por sección (funds > etfs > bonds > equities …)
+ *      · Búsqueda por ISIN con ranking por sección (funds > etfs > bonds > equities > indices > currencies > crypto > certificates)
  *      · Detección de DIVISA contextual al precio (evita falsos USD)
  *  - GOOGLEFINANCE (página pública de Google Finance)
  *
@@ -335,7 +335,7 @@ function _investingPickBestLinkByIsin(html, isin, hint) {
 
   const SECTION_PRIORITY = {
     "funds": 90, "etfs": 80, "bonds": 70, "equities": 60,
-    "indices": 40, "currencies": 30, "crypto": 20, "certificates": 50
+    "indices": 40, "currencies": 30, "crypto": 20, "certificates": 10
   };
 
   function score(c) {


### PR DESCRIPTION
## Summary
- Lower certificates section priority below crypto for Investing ISIN search
- Document full section ranking order

## Testing
- `node -e "const fs=require('fs'); eval(fs.readFileSync('codigo.gs','utf8')); console.log('syntax ok');"`
- `node -e "const fs=require('fs'); eval(fs.readFileSync('codigo.gs','utf8')); const html='<a href=\"/crypto/abc\"></a><a href=\"/certificates/abc\"></a>'; const res=_investingPickBestLinkByIsin(html,'',''); console.log(res);"`
- `node -e "const SECTION_PRIORITY={funds:90, etfs:80, bonds:70, equities:60, indices:40, currencies:30, crypto:20, certificates:10}; const candidates=[{section:'crypto'},{section:'certificates'},{section:'bonds'}]; function score(c){return SECTION_PRIORITY[c.section]||10;} candidates.sort((a,b)=>score(b)-score(a)); console.log(candidates.map(c=>c.section));"`

------
https://chatgpt.com/codex/tasks/task_e_68adf93c7980832faef174685d0f2f52