### PR TITLE
docs: update cache note to 6h

### DIFF
--- a/codigo.gs
+++ b/codigo.gs
@@ -19,7 +19,7 @@
  *  - resolveQuoteByIsin(isin, hint, strictFunds)
  *
  * Notas:
- *  - CacheService para reducir llamadas (60–300 s).
+ *  - CacheService para reducir llamadas (60 s–6 h).
  *  - Uso responsable de fuentes públicas; evita abusos.
  *  - Config ES: en celdas usa ; como separador de argumentos.
  */


### PR DESCRIPTION
## Summary
- clarify cache note to indicate support for up to 6 hours

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adf965d56c832f8361b1e06c8d2c31