### PR TITLE
Add tests for European number parser

### DIFF
--- a/codigo.gs
+++ b/codigo.gs
@@ -54,6 +54,7 @@ function _toNumber(x) {
 function _parseEuropeanNumber(s) {
   if (!s || typeof s !== "string") return "";
   s = s.trim().replace(/[^\d,.\-]/g, "");
+  if (s === "") return "";
   if (s.indexOf(",") > -1 && s.indexOf(".") > -1) s = s.replace(/\./g, "").replace(",", ".");
   else if (s.indexOf(",") > -1) s = s.replace(",", ".");
   const n = Number(s);

--- a/tests/parseEuropeanNumber.test.gs
+++ b/tests/parseEuropeanNumber.test.gs
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+// Load the Apps Script code
+const code = fs.readFileSync(require('path').join(__dirname, '..', 'codigo.gs'), 'utf8');
+const sandbox = {};
+vm.runInNewContext(code, sandbox);
+const parseEuropeanNumber = sandbox._parseEuropeanNumber;
+
+// Valores con punto de miles y coma decimal
+assert.strictEqual(parseEuropeanNumber('1.234,56'), 1234.56);
+
+// Números negativos
+assert.strictEqual(parseEuropeanNumber('-123,45'), -123.45);
+
+// Entradas inválidas que deben devolver cadena vacía
+assert.strictEqual(parseEuropeanNumber('abc'), '');
+assert.strictEqual(parseEuropeanNumber(null), '');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add unit tests for `_parseEuropeanNumber` covering thousands separators, negatives, and invalid inputs
- fix `_parseEuropeanNumber` to return empty string for non-numeric values

## Testing
- `node tests/parseEuropeanNumber.test.gs`


------
https://chatgpt.com/codex/tasks/task_e_68adfaa27f78832f90433004b85a6e7c