### PR TITLE
feat: add Financial Times source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# marketdatabase
-Apps Script para buscar y extraer información de activos financieros
+# MarketDataService
+
+Biblioteca de Google Apps Script para consultar precios de mercado de diferentes fuentes públicas.
+
+## Características
+
+- Consulta unificada de fondos, ETFs, acciones y criptomonedas.
+- Fuentes soportadas: Investing, Quefondos, Financial Times, Yahoo Finance y Google Finance.
+- Caché temporal mediante `CacheService` para reducir llamadas a la red.
+
+## Instalación
+
+1. Abre un documento de Google Sheets.
+2. Ve a **Extensiones → Apps Script**.
+3. Crea un proyecto y pega el contenido de `codigo.gs`.
+4. Guarda el proyecto con un nombre, por ejemplo `MarketDataService`.
+
+## Uso
+
+Las funciones devuelven una única fila con el formato:
+
+`{ Nombre ; Ticker ; Precio ; Divisa ; Fuente ; FechaISO }`
+
+Ejemplos en una celda (configuración regional española):
+
+```
+=resolveQuote("FINANCIALTIMES"; "NVDA:NSQ")
+=resolveQuoteByIsin("LU2601038735"; ; TRUE)
+```
+
+Puedes combinar la salida con `INDEX` u otras funciones de Google Sheets para obtener un campo concreto.
+
+### resolveQuote(source, identifier)
+Obtiene la cotización directamente de la fuente indicada.
+
+### resolveQuoteByIsin(isin, [hint], [strictFunds])
+Busca por ISIN aplicando un orden de *fallback*: Investing → Quefondos → FinancialTimes → (solo no fondos) Yahoo Finance → Google Finance.
+
+## Licencia
+
+Uso personal y educativo. Respeta los términos de servicio de cada fuente.
+

--- a/codigo.gs
+++ b/codigo.gs
@@ -772,7 +772,7 @@ function _extractFtName(html) {
 }
 
 /**
- * Extrae el precio desde el HTML de Financial Times.
+ * Extrae el precio desde el HTML de Financial Times (decimales con punto).
  * @param {string} html
  * @return {number|""}
  */
@@ -780,20 +780,25 @@ function _extractFtPrice(html) {
   if (!html) return "";
   var m = /Price\s*\(([A-Z]{3})\)\s*<\/span>\s*<span[^>]*>([0-9][0-9\.,]*)/i.exec(html);
   if (m && m[2]) {
-    var n = _parseEuropeanNumber(m[2]);
+    var n = Number(m[2].replace(/,/g, ""));
     if (!isNaN(n)) return n;
   }
   m = /"last"\s*:\s*([0-9][0-9\.,]*)/i.exec(html);
   if (m && m[1]) {
-    var n2 = _parseEuropeanNumber(m[1]);
+    var n2 = Number(m[1].replace(/,/g, ""));
     if (!isNaN(n2)) return n2;
   }
   m = /Last\s+price[^0-9]*([0-9][0-9\.,]*)/i.exec(html);
   if (m && m[1]) {
-    var n3 = _parseEuropeanNumber(m[1]);
+    var n3 = Number(m[1].replace(/,/g, ""));
     if (!isNaN(n3)) return n3;
   }
-  return _firstNumberLike(html);
+  var mfallback = html.match(/[-+]?\d{1,3}(,\d{3})*(\.\d+)?/);
+  if (mfallback && mfallback[0]) {
+    var nfallback = Number(mfallback[0].replace(/,/g, ""));
+    if (!isNaN(nfallback)) return nfallback;
+  }
+  return "";
 }
 
 /**

--- a/codigo.gs
+++ b/codigo.gs
@@ -778,15 +778,20 @@ function _extractFtName(html) {
  */
 function _extractFtPrice(html) {
   if (!html) return "";
-  var m = /"last"\s*:\s*([0-9][0-9\.,]*)/i.exec(html);
-  if (m && m[1]) {
-    var n = _parseEuropeanNumber(m[1]);
+  var m = /Price\s*\(([A-Z]{3})\)\s*<\/span>\s*<span[^>]*>([0-9][0-9\.,]*)/i.exec(html);
+  if (m && m[2]) {
+    var n = _parseEuropeanNumber(m[2]);
     if (!isNaN(n)) return n;
   }
-  m = /Last\s+price[^0-9]*([0-9][0-9\.,]*)/i.exec(html);
+  m = /"last"\s*:\s*([0-9][0-9\.,]*)/i.exec(html);
   if (m && m[1]) {
     var n2 = _parseEuropeanNumber(m[1]);
     if (!isNaN(n2)) return n2;
+  }
+  m = /Last\s+price[^0-9]*([0-9][0-9\.,]*)/i.exec(html);
+  if (m && m[1]) {
+    var n3 = _parseEuropeanNumber(m[1]);
+    if (!isNaN(n3)) return n3;
   }
   return _firstNumberLike(html);
 }
@@ -798,7 +803,9 @@ function _extractFtPrice(html) {
  */
 function _extractFtCurrency(html) {
   if (!html) return "";
-  var m = /"currency"\s*:\s*"([A-Z]{3})"/i.exec(html);
+  var m = /Price\s*\(([A-Z]{3})\)\s*<\/span>\s*<span[^>]*>[0-9]/i.exec(html);
+  if (m && m[1]) return m[1].toUpperCase();
+  m = /"currency"\s*:\s*"([A-Z]{3})"/i.exec(html);
   if (m && m[1]) return m[1].toUpperCase();
   m = /data-currency\s*=\s*"([A-Z]{3})"/i.exec(html);
   if (m && m[1]) return m[1].toUpperCase();


### PR DESCRIPTION
## Summary
- add Financial Times quote scrapers for funds, ETFs and stocks
- route FINANCIALTIMES in resolveQuote and fallback by ISIN
- document library usage for Apps Script

## Testing
- `node --check codigo.gs` (fails: Unknown file extension)
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ae4b6bfcac832f9210ec7e2bf034b8